### PR TITLE
Add GH Action to upload coverage report

### DIFF
--- a/.github/workflows/codeclimate.yml
+++ b/.github/workflows/codeclimate.yml
@@ -1,0 +1,43 @@
+name: Tests pipeline
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the dev branch
+  push:
+    branches: [ dev ]
+    
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Django Testing project
+      run: |
+        python manage.py makemigrations
+        python manage.py migrate
+        coverage run manage.py test
+        coverage report
+        coverage xml
+    - name: Publish tests to Code Climate
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x cc-test-reporter
+        ./cc-test-reporter format-coverage -t coverage.py coverage.xml
+        ./cc-test-reporter upload-coverage
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fga-eps-mds_2020.2-Projeto-Kokama-Ensino&metric=alert_status)](https://sonarcloud.io/dashboard?id=fga-eps-mds_2020.2-Projeto-Kokama-Ensino)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/1bdc4e33130256a041b6/test_coverage)](https://codeclimate.com/github/fga-eps-mds/2020.2-Projeto-Kokama-Ensino/test_coverage)
 
 # 2020.2-Projeto-Kokama-Ensino
 


### PR DESCRIPTION
## Descrição 

Criação do scritp de verificação dos testes para incluir upload para o Code Climate, gerando a badge de cobertura.

**Resolve parcialmente a issue [#186](https://github.com/fga-eps-mds/2020.2-Projeto-Kokama-Wiki/issues/186).**

## Tarefas realizadas

- [x] Realizar upload do arquivo de report ao CodeClimate;
- [x] Apresentar a badge de cobertura.